### PR TITLE
readme_create

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,58 @@ Things you may want to cover:
 * Deployment instructions
 
 * ...
+|Column|Type|Options|
+|------|----|-------|
+|name|string|null: false|
+|password|string|null: false|
+|email|string|null: false,unique: true|
+
+### Association
+has_many :user_groups
+has_many :groups, through: :user_groups
+has_many :messages
+
+
+## groupsテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|name|string|null: false|
+
+
+### Association
+has_many :user_groups
+has_many :users, through: :user_groups
+has_many :messages
+
+## user_groupsテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+
+### Association
+belongs_to :user
+belongs_to :group
+
+## messagesテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|message|text|
+|image|string|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+
+### validation
+validates :message_or_image, presence: true
+
+private
+  def email_or_phone
+    message.presence or image.presence
+  end
+
+### Association
+belongs_to :user
+belongs_to :group

--- a/README.md
+++ b/README.md
@@ -66,13 +66,6 @@ belongs_to :group
 |user_id|integer|null: false, foreign_key: true|
 |group_id|integer|null: false, foreign_key: true|
 
-### validation
-validates :message_or_image, presence: true
-
-private
-  def email_or_phone
-    message.presence or image.presence
-  end
 
 ### Association
 belongs_to :user


### PR DESCRIPTION
#WHAT
.READMEにデータベースに必要なテーブル名とそれぞれのカラム名を記載。
テーブル名（users, groups, user_groups, message )
user_groupsはusersとgroupsの多対多の関係を解消するため。

.すべきアソシエーションとバリデーションも記載。
バリデーションは空のままメッセージを投稿されないように、メッセージまたは画像のどちらかを必要とするバリデーションにしている。

#WHY
今後、創造すると思われるデータベースの理想図に誤があるかないかをメンターさんに確認してもらうため。
